### PR TITLE
Sort task instances again before queued

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -910,7 +910,7 @@ class SchedulerJob(BaseJob):
 
         # update the state of the previously active dag runs
         dag_runs = DagRun.find(dag_id=dag.dag_id, state=State.RUNNING, session=session)
-       if self.policy_lifo:
+        if self.policy_lifo:
             dag_runs = sorted(dag_runs, key=lambda dr: dr.execution_date, reverse=True)
 
         active_dag_runs = []


### PR DESCRIPTION
This change adds another task instance sort before tasks are actually queued.

The [previous change](https://github.com/KittyHawkCorp/incubator-airflow/pull/4) added sort before tasks are marked "SCHEDULED". After that, however, there is another process that selects "SCHEDULED" tasks and publishes to queue.

With this change, tasks with recent execution date are marked "SCHEDULED" **and** actually published to the queue.


Tested in staging
* cleared task instances from t0 to t1 (t0 < t1 < now)
* triggered the workflow to create a fresh dag run.
* confirmed the new dag run is scheduled before the reruns
* also confirmed the rerunning ones are scheduled in reverse order of execution date.